### PR TITLE
Fix RLock issue introduced on the last PR

### DIFF
--- a/etcdlock/rwmutex2.go
+++ b/etcdlock/rwmutex2.go
@@ -35,6 +35,7 @@ func (rwm *RWMutex) RLock(ctx context.Context) error {
 		if dErr := rwm.myKey.Delete(); dErr != nil {
 			return errors.New(fmt.Sprintf("error getting lock: %s; error deleting key %s from etcd: %s.", err.Error(), rwm.myKey.key, dErr.Error()))
 		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fix the issue that hides error on RLock method when waitOnLastRev returns an error and delete keys does not return an error.

I forgot to return the error from function waitOnLastRev and the unit and integration tests was not covering that case.

I updated the integration tests and fixed the error.